### PR TITLE
Fix menu update mutation bug

### DIFF
--- a/lib/datas/menu_data/write_data_menu.dart
+++ b/lib/datas/menu_data/write_data_menu.dart
@@ -105,13 +105,11 @@ class WriteMenuData {
 
         Map<String, dynamic>? oldItem;
 
-        // eski itemı sil
-        for (var item in menu) {
-          if (item["name"] == itemName) {
-            oldItem = item;
-            menu.remove(item);
-            break;
-          }
+        // eski itemi bulup kaldır
+        int index = menu.indexWhere((item) => item["name"] == itemName);
+        if (index != -1) {
+          oldItem = menu[index];
+          menu.removeAt(index);
         }
 
         if (oldItem != null) {


### PR DESCRIPTION
## Summary
- fix runtime crash when removing an existing menu item during update

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847df4b02d4832b90eae91ad65dc503